### PR TITLE
fix CMake build: .c and stdc++fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,19 @@ build/
 bin/
 Debug/
 Release/
+Lem3Edit.opensdf
+Lem3Edit.sdf
+Lem3Edit.sln
+Lem3Edit.vcxproj
+Lem3Edit.vcxproj.filters
+.vs/
 
-# Files by Lemmings 3 that we instruct the user to add to our project's root
+# Files that the editor will create itself
+lem3edit.ini
+
+# Files by Lemmings 3 that might be added in the project root.
+# Ideally, these shouldn't be put into the project, but rather the
+# project should point to L3CD.EXE in a separate directory.
 AUDIO/
 FRONT/
 GRAPHICS/
@@ -19,9 +30,3 @@ L3CD.EXE
 L3CDGUS.EXE
 L3GUS.BAT
 USER.DAT
-Lem3Edit.opensdf
-Lem3Edit.sdf
-Lem3Edit.sln
-Lem3Edit.vcxproj
-Lem3Edit.vcxproj.filters
-.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 find_package(SDL2 REQUIRED)
 find_package(SDL2_ttf REQUIRED)
 
-file(GLOB_RECURSE lem3editSources "src/*.cpp")
+file(GLOB_RECURSE lem3editSources "src/*.cpp" "src/*.c")
 include_directories(${SDL2_INCLUDE_DIR} ${SDL2_TTF_INCLUDE_DIR})
 
 add_executable(lem3edit ${lem3editSources})
-target_link_libraries(lem3edit ${SDL2_LIBRARY} ${SDL2_TTF_LIBRARIES})
+target_link_libraries(lem3edit ${SDL2_LIBRARY} ${SDL2_TTF_LIBRARIES} stdc++fs)


### PR DESCRIPTION
Tiny File Dialogs ships with lem3edit, but it's a .c file. Let CMake
find these files. Let CMake link against libstdc++fs, the filesystem
library. I don't test during configuration whether this exists --
if somebody needs to link against something different, tell me.